### PR TITLE
various changes

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -261,27 +261,26 @@ class JobManager():
     def count_jobs(self, status_filter=None):
         return len(self.list_jobs(status_filter))
 
-    # returns a list of all workers, or optionally only the active ones
-    def list_workers(self, active_only=False):
+    # returns a list of workers, optionally filtered by activity or worker type
+    def list_workers(self, active_only=False, filter_type=None):
+        workers = []
         with self.lock:
-            if active_only:
-                return [m for m in self.workers.values() if not m.has_timed_out()]
-            else:
+            if not (active_only or filter_type):
                 return self.workers.values()
+            for worker in self.workers.values():
+                if filter_type and worker.type != filter_type:
+                    continue
+                if active_only and not worker.has_timed_out():
+                    workers.append(worker)
+                elif not active_only:
+                    workers.append(worker)
+            return workers
 
     def list_miners(self, active_only=False):
-        miners = []
-        for worker in self.list_workers(active_only):
-            if worker.type == "miiner":
-                miners.append(worker)
-        return miners
+        return self.list_workers(active_only, "miiner")
 
     def list_friendbots(self, active_only=False):
-        friendbots = []
-        for worker in self.list_workers(active_only):
-            if worker.type == "friendbot":
-                friendbots.append(worker)
-        return friendbots
+        return self.list_workers(active_only, "friendbot")
 
     # returns the number of workers, optionally only counting the active ones
     def count_workers(self, active_only=False):

--- a/server.py
+++ b/server.py
@@ -289,6 +289,7 @@ def api_list_claimed_jobs():
     claimed = []
     for job in manager.list_jobs(status_filter="working"):
         if job.get_assignee_name() == worker_name:
+            job.update()  # update job to avoid server timing it out
             claimed.append(dict(job))
     return success({"jobs": claimed})
 

--- a/server.py
+++ b/server.py
@@ -278,6 +278,20 @@ def api_fail_job(key: str):
     app.logger.info(f'{log_prefix(key)} failed')
     return success()
 
+@app.route('/api/list_claimed_jobs')
+def api_list_claimed_jobs():
+    worker_name = request.args.get("name")
+    if not worker_name:
+        return error("No worker name provided")
+    # maybe fallback to matching by ip?
+    # downside would be slower and potential for returning wrong job types
+    # if there was a friendbot and miner running on the same ip unless a type is also provided
+    claimed = []
+    for job in manager.list_jobs(status_filter="working"):
+        if job.get_assignee_name() == worker_name:
+            claimed.append(dict(job))
+    return success({"jobs": claimed})
+
 @app.route('/api/check_network_stats')
 def api_check_network_stats():
     return success({

--- a/server.py
+++ b/server.py
@@ -237,7 +237,7 @@ def api_reset_job(key: str):
 
 @app.route('/api/complete_job/<key>', methods=['POST'])
 def api_complete_job(key: str):
-    global mseds_mined
+    global mseds_mined, lfcses_mined, lfcses_dumped
     if not is_job_key(key):
         return error('Invalid Job Key')
     # get raw result data


### PR DESCRIPTION
- move worker type filtering to list_workers
- fix UnboundLocalError in api_complete_job
- add endpoint to list claimed jobs (friendbot uses it)

worth noting that using the friendbot's timeout doesn't just mean that the length of the time before it expires is different but also the friendbot timeout will fail the job instead of just resetting it 