### PR TITLE
Add a list of known friend codes and blacklist them

### DIFF
--- a/blacklist.py
+++ b/blacklist.py
@@ -1,0 +1,36 @@
+#
+# List of friend codes to be blacklisted from BFM/MovableQ
+# Copyright (c) 2021-2022 eip618
+# Copyright (c) 2023 CM360
+#
+# SPDX-License-Identifier: MIT
+#
+
+# These friend codes are taken either from video guides or friendbot's FCs.
+# These should not be accepted; users often enter the friend code seen in 
+# video guides instead of their own
+FC_knownFriendCodes = [
+    '113541082053',  # valid            
+    '281029350533',  # RANDAL           
+    '190853507948',  # ASP              
+    '504323700474',  # BLECK            
+    '044826694144',  # STHETIX          
+    '448554640094',  # HANSOL          
+    '242389963248',  # P3NCE            
+    '285283849153',  # P3NCE            
+    '435668835763',  # P3NCE            
+    '345470646642',  # BLAINE LOCKLAIR  
+    '139284223032',  # BLAINE LOCKLAIR  
+    '392718681180',  # BLAINE LOCKLAIR  
+    '332569869337',  # NINTENDOBREW     
+    '422783820021',  # KELONIO 3DS      
+    '238097183111',  # LOPEZ TUTORIALES 
+    '109249029780',  # LOPEZ TUTORIALES 
+    '517271779247',  # LOPEZ TUTORIALES 
+    '220920415112',  # LOPEZ TUTORIALES 
+    '384125672247',  # THEWIZWIKI       
+    '143609644804',  # THEWIZWIKI       
+    '354064119835',  # THEWIZWIKI       
+    '547304741531',  # DARKFELIN         
+    '233801992881'   # LINK GAMEPLAY   
+]

--- a/server.py
+++ b/server.py
@@ -28,7 +28,7 @@ from dotenv import load_dotenv
 
 # MovableQ modules
 from jobs import JobManager, Job, FcLfcsJob, MiiLfcsJob, MsedJob, read_movable, count_mseds_mined, count_lfcses_mined, count_lfcses_dumped
-from validators import is_job_key, is_id0, is_system_id, is_friend_code, validate_job_result, enforce_client_version
+from validators import is_job_key, is_id0, is_system_id, is_friend_code, is_blacklisted_friend_code, validate_job_result, enforce_client_version
 
 
 # AES keys are loaded from .env
@@ -534,7 +534,7 @@ def parse_fc_job(job_data) -> FcLfcsJob:
     try:
         # friend code
         friend_code = job_data['friend_code'].replace('-', '')
-        if not is_friend_code(friend_code):
+        if not is_friend_code(friend_code) or is_blacklisted_friend_code(friend_code):
             raise InvalidSubmissionFieldError(['friend_code'])
         else:
             return FcLfcsJob(friend_code)

--- a/validators.py
+++ b/validators.py
@@ -2,6 +2,7 @@ import hashlib
 import re
 import struct
 
+import blacklist
 
 id0_regex = re.compile(r'(?![0-9a-fA-F]{4}(01|00)[0-9a-fA-F]{18}00[0-9a-fA-F]{6})[0-9a-fA-F]{32}')
 system_id_regex = re.compile(r'[a-fA-F0-9]{16}')
@@ -37,6 +38,11 @@ def is_friend_code(value: str) -> bool:
     principal_id = fc & 0xFFFFFFFF
     checksum = (fc & 0xFF00000000) >> 32
     return hashlib.sha1(struct.pack('<L', principal_id)).digest()[0] >> 1 == checksum
+
+# Verify if friend code is not statically blacklisted (vguides etc)
+# Returns true if blacklisted, false otherwise
+def is_blacklisted_friend_code(value: str) -> bool:
+    return value in blacklist.FC_knownFriendCodes
 
 def get_key_type(key: str) -> str:
     if is_friend_code(key):


### PR DESCRIPTION
This imports a list of friend codes currently blacklisted on Bruteforce Movable.

The list of friend codes seen in blacklist.py are shown often in video guides or viewed when a friendbot's friend code appears somewhere. In neither of these cases should these be allowed to be mined, as it is known for a fact that these are not the end user's friend code.